### PR TITLE
Improve error for missing Clojure.dll and make PATH seperator cross-platform

### DIFF
--- a/Editor/Initialization.cs
+++ b/Editor/Initialization.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEditor;
 using clojure.lang;
@@ -11,53 +12,81 @@ namespace Arcadia {
     static Initialization() {
       Initialize();
     }
-      
+
     [MenuItem ("Arcadia/Initialization/Rerun")]
     public static void Initialize() {
       Debug.Log("Starting Arcadia...");
-      
+
       CheckSettings();
       SetClojureLoadPath();
       StartREPL();
-      
-      Debug.Log("Arcadia Started!");    
+
+      Debug.Log("Arcadia Started!");
     }
-    
+
     public static void CheckSettings() {
       Debug.Log("Checking Unity Settings...");
       if(PlayerSettings.apiCompatibilityLevel != ApiCompatibilityLevel.NET_2_0) {
         Debug.Log("Updating API Compatibility Level");
         PlayerSettings.apiCompatibilityLevel = ApiCompatibilityLevel.NET_2_0;
       }
-      
+
       if(!PlayerSettings.runInBackground) {
         Debug.Log("Updating Run In Background");
         PlayerSettings.runInBackground = true;
       }
     }
 
-    public static void SetClojureLoadPath() {
-      try {
-        Debug.Log("Setting Load Path...");
-        string clojureDllFolder = Path.GetDirectoryName(
-          AssetDatabase.GetAllAssetPaths()
-            .Where(s => System.Text.RegularExpressions.Regex.IsMatch(s, ".*/Clojure.dll$")) // for compatibility with 4.3
-            .Single());
-        
-        Environment.SetEnvironmentVariable("CLOJURE_LOAD_PATH",
-          Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Compiled")) + ":" +
-          Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Source")) + ":" +
-          Path.GetFullPath(Application.dataPath));
-        Debug.Log("Load Path is " + Environment.GetEnvironmentVariable("CLOJURE_LOAD_PATH"));
-      } catch(InvalidOperationException e) {
-        throw new SystemException("Error Loading Arcadia! Arcadia expects exactly one Arcadia folder (a folder with Clojure.dll in it)");
+    static string FindClojureDll() {
+      var paths = AssetDatabase.GetAllAssetPaths()
+        .Where(p => Regex.IsMatch(p, @".*/Clojure\.dll$"))
+        .Select(p => Path.GetDirectoryName(p));
+
+      if (paths.Count() > 1) {
+        string error = "Found multiple directories containing Clojure.dll:\n";
+
+        foreach (var path in paths)
+        {
+          error += String.Format(" - \"{0}\"\n", path);
+        }
+
+        throw new Exception(error);
+      }
+      else if (!paths.Any()) {
+        throw new Exception("Found no directories containing Clojure.dll!");
+      }
+
+      Debug.Log(String.Format("Found Clojure.dll in \"{0}\"", paths.First()));
+      return paths.First();
+    }
+
+    static string PathSeperator() {
+      if (SystemInfo.operatingSystem.ToLower().Contains("windows")) {
+        return ";";
+      }
+      else {
+        return ":";
       }
     }
-    
+
+    public static void SetClojureLoadPath()
+    {
+      Debug.Log("Setting Load Path...");
+
+      string clojureDllFolder = FindClojureDll();
+      string sep = PathSeperator();
+
+      Environment.SetEnvironmentVariable("CLOJURE_LOAD_PATH",
+        Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Compiled")) + sep +
+        Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Source")) + sep +
+        Path.GetFullPath(Application.dataPath));
+      Debug.Log("Load Path is " + Environment.GetEnvironmentVariable("CLOJURE_LOAD_PATH"));
+    }
+
     static void StartREPL() {
       ClojureRepl.StartREPL();
     }
-    
+
     // old mono...
     static string VariadicCombine(params string[] paths) {
       string path = "";
@@ -66,5 +95,5 @@ namespace Arcadia {
       }
       return path;
     }
-  } 
+  }
 }


### PR DESCRIPTION
On my machine, I found that the `Initialize` method was being called twice. The first time it would fail because it couldn't find the DLL and the second time it would succeed. While I was trying to figure out why this wasn't working I changed the error logging to be more specific. I also found that I needed to change the path separator from a colon to a semi-colon on windows, so I added some code to figure it out.

Not sure if you want to use any of these changes. But I thought I would share anyway.
