### PR TITLE
Adds nested folders, hyphens->underscores to new clj file creation

### DIFF
--- a/Editor/ClojureNewFile.cs
+++ b/Editor/ClojureNewFile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -10,28 +11,93 @@ using UnityEditor.ProjectWindowCallback;
 using clojure.lang;
 
 public class ClojureNewFile : EditorWindow {
-  // TODO support nested folders, hyphen/underscores
   // TODO read file paths from config
+
+  private const string DefaultScriptPath = "Assets";
+
   [MenuItem ("Assets/Create/Clojure Component", false, 90)]
   [MenuItem ("Arcadia/New Component", false, 90)]
   public static void NewComponent () {
-    var DoCreateScriptAsset = Type.GetType("UnityEditor.ProjectWindowCallback.DoCreateScriptAsset, UnityEditor");
-    
-    ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0,
-      ScriptableObject.CreateInstance(DoCreateScriptAsset) as UnityEditor.ProjectWindowCallback.EndNameEditAction,
-      "Assets/Clojure/Scripts/new-component.clj",
-      null,
-      "Assets/Clojure/Editor/new-component-template.clj.txt");
+    CreateFromTemplate("new-component.clj", "Assets/Arcadia/Editor/new-component-template.clj.txt");
   }
   
   [MenuItem ("Arcadia/New File", false, 91)]
   public static void NewFile () {
-    var DoCreateScriptAsset = Type.GetType("UnityEditor.ProjectWindowCallback.DoCreateScriptAsset, UnityEditor");
-    
-    ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0,
-      ScriptableObject.CreateInstance(DoCreateScriptAsset) as UnityEditor.ProjectWindowCallback.EndNameEditAction,
-      "Assets/Clojure/Scripts/new-file.clj",
-      null,
-      "Assets/Clojure/Editor/new-file-template.clj.txt");
+    CreateFromTemplate("new-file.clj", "Assets/Arcadia/Editor/new-file-template.clj.txt");
   }
+
+  private static void CreateFromTemplate(string path, string templatePath) {
+    ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0,
+      CreateInstance<ClojureNewFileEndNameEditAction>(),
+      GetUniqueFilename(path),
+      null,
+      templatePath);
+  }
+
+  /**
+   * Given a filename, return a unique version of it, relative to the current selection in the Project window, if any.
+   */
+  private static string GetUniqueFilename(string filename) {
+    string path = null;
+    var selection = Selection.GetFiltered(typeof (UnityEngine.Object), SelectionMode.Assets).FirstOrDefault();
+    if (selection != null) {
+      path = AssetDatabase.GetAssetPath(selection);
+      if (File.Exists(path)) {
+        path = Path.GetDirectoryName(path);
+      }
+    }
+    if (path == null) {
+      path = DefaultScriptPath;
+    }
+
+    return AssetDatabase.GenerateUniqueAssetPath(Path.Combine(path, filename));
+  }
+}
+
+/**
+ * Helper ScriptableObject whose Action method will be invoked by Unity when the user finishes editing
+ * the name of an asset in the Project window.
+ * 
+ * Creates a new script at the given path using the contents of a template, 
+ * replacing '#NAMESPACE#' and '#COMPONENTNAME#' tags with appropriate values.
+ */
+public class ClojureNewFileEndNameEditAction : UnityEditor.ProjectWindowCallback.EndNameEditAction {
+  public override void Action(int i, string path, string templatePath) {
+
+    var filename = Path.GetFileName(path);
+    var dir = Path.GetDirectoryName(path);
+    if (filename == null) return;
+    if (dir == null) dir = "";
+
+    dir = Path.Combine(Environment.CurrentDirectory, dir);
+
+    // hyphens to underscores
+    var outPath = Path.Combine(dir, filename.Replace('-', '_'));
+    // create the output file and open a StreamWriter
+    var writer = File.CreateText(outPath);
+
+    // now ask arcadia.compiler what the namespace should be
+    // note that we have to do this *after* the file exists, or we'll get a nil result
+    var nsSym = (Symbol) RT.var("arcadia.compiler", "asset->ns").invoke(outPath);
+    if (nsSym == null) {
+      Debug.LogWarning("Unable to determine namespace for " + outPath + ". Is it on the compiler load-path?");
+      writer.Dispose();
+      File.Delete(outPath);
+      return;
+    }
+
+    // slurp up the template and replace ##NAMESPACE## with the namespace and ##SCRIPTNAME## with the last namespace component
+    // writing the result to our destination
+    var ns = nsSym.Name;
+    var component = ns.Split('.').Last();
+    var tmpl = File.ReadAllText(templatePath);
+    var contents = Regex.Replace(tmpl, "#NAMESPACE#", ns);
+    contents = Regex.Replace(contents, "#COMPONENTNAME#", component);
+    writer.Write(contents);
+    writer.Close();
+
+    AssetDatabase.Refresh();
+  }
+
+
 }

--- a/Editor/ClojureNewFile.cs
+++ b/Editor/ClojureNewFile.cs
@@ -64,7 +64,7 @@ public class ClojureNewFileEndNameEditAction : UnityEditor.ProjectWindowCallback
     var filename = Path.GetFileName(path);
     var dir = Path.GetDirectoryName(path);
     if (filename == null) return;
-    if (dir == null) dir = DefaultScriptPath;
+    if (dir == null) dir = "Assets";
 
     dir = Path.Combine(Environment.CurrentDirectory, dir);
 

--- a/Editor/ClojureNewFile.cs
+++ b/Editor/ClojureNewFile.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Linq;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.RegularExpressions;
 
 using UnityEngine;
 using UnityEditor;
-using UnityEditor.ProjectWindowCallback;
 using clojure.lang;
 
 public class ClojureNewFile : EditorWindow {
@@ -86,7 +83,7 @@ public class ClojureNewFileEndNameEditAction : UnityEditor.ProjectWindowCallback
       return;
     }
 
-    // slurp up the template and replace ##NAMESPACE## with the namespace and ##SCRIPTNAME## with the last namespace component
+    // slurp up the template and replace #NAMESPACE# with the namespace and #COMPONENTNAME# with the last namespace component
     // writing the result to our destination
     var ns = nsSym.Name;
     var component = ns.Split('.').Last();

--- a/Editor/ClojureNewFile.cs
+++ b/Editor/ClojureNewFile.cs
@@ -64,7 +64,7 @@ public class ClojureNewFileEndNameEditAction : UnityEditor.ProjectWindowCallback
     var filename = Path.GetFileName(path);
     var dir = Path.GetDirectoryName(path);
     if (filename == null) return;
-    if (dir == null) dir = "";
+    if (dir == null) dir = DefaultScriptPath;
 
     dir = Path.Combine(Environment.CurrentDirectory, dir);
 

--- a/Editor/new-component-template.clj.txt
+++ b/Editor/new-component-template.clj.txt
@@ -1,8 +1,8 @@
-(ns #SCRIPTNAME#
+(ns #NAMESPACE#
   (:use arcadia.core)
   (:import [UnityEngine Debug]))
 
-(defcomponent #SCRIPTNAME# []
+(defcomponent #COMPONENTNAME# []
   ; use this for initialization
   (Start [this])
   

--- a/Editor/new-file-template.clj.txt
+++ b/Editor/new-file-template.clj.txt
@@ -1,4 +1,4 @@
-(ns #SCRIPTNAME#
+(ns #NAMESPACE#
   (:use arcadia.core)
   (:import [UnityEngine Debug]))
 


### PR DESCRIPTION
Hi, this cleans up creation of new files a bit, and adds support for nested folders.  New Clojure files will be created relative to the Project window's selection, if anything is selected, otherwise it defaults to "Assets".  Also, we set the namespace of new files based on the path, relative to the compiler load-path.  This works by just asking `arcadia.compiler/asset->ns` what it thinks the namespace should be.

Right now it fails with a warning if you try to create a file outside of the load-path, but since "Assets" is on the load-path by default, that shouldn't be possible.

This changes the templates a bit to have `#NAMESPACE#` and `#COMPONENTNAME#` tags instead of `#SCRIPTNAME#`, since we're doing the substitution ourselves instead of having Unity do it.
