### PR TITLE
Compiled Clojure DLLs have a GUID generated for them

### DIFF
--- a/Source/arcadia/compiler.clj
+++ b/Source/arcadia/compiler.clj
@@ -140,9 +140,10 @@
    (.ComputeHash (MD5/Create) (.GetBytes Encoding/UTF8 text))))
 
 (defn import-compiled [asset]
-  (let [guid (hash-string (s/replace asset #"\.clj\.dll" ""))
-        meta (str asset ".meta")]
-    (Debug/Log (format "Generating GUID for compiled DLL '%s'" asset))
+  (let [file (Path/GetFileNameWithoutExtension asset)
+        meta (str asset ".meta")
+        guid (hash-string file)]
+    (Debug/Log (format "GUID for compiled DLL '%s' is '%s'" file guid))
     (spit meta (s/replace (slurp meta) #"\b[0-9a-f]{32}\b" guid))))
 
 (defn import-assets [imported]


### PR DESCRIPTION
This is a fix for #117. Rather than let Unity generate the GUID we hash the namespace and use it instead. Because it is deterministic you shouldn't lose connections to scene objects.

The outstanding problem is that re-importing the compiled DLLs isn't automatic. If someone clones down a project with only .clj files, they will need to do a manual re-import to get everything compiled before editing scenes.

Hope this is of use!
