### PR TITLE
Fix CLOJURE_LOAD_PATH on Windows

### DIFF
--- a/Editor/Initialization.cs
+++ b/Editor/Initialization.cs
@@ -45,8 +45,8 @@ namespace Arcadia {
             .Single());
         
         Environment.SetEnvironmentVariable("CLOJURE_LOAD_PATH",
-          Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Compiled")) + ":" +
-          Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Source")) + ":" +
+          Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Compiled")) + Path.PathSeparator +
+          Path.GetFullPath(VariadicCombine(clojureDllFolder, "..", "Source")) + Path.PathSeparator +
           Path.GetFullPath(Application.dataPath));
         Debug.Log("Load Path is " + Environment.GetEnvironmentVariable("CLOJURE_LOAD_PATH"));
       } catch(InvalidOperationException e) {


### PR DESCRIPTION
Using Path.PathSeparator (instead of the literal ":" string) ensures that the CLOJURE_LOAD_PATH environment variable uses the appropriate separator character for the current platform.
