### PR TITLE
Fix Awake Hook

### DIFF
--- a/Components/ArcadiaBehaviour.cs
+++ b/Components/ArcadiaBehaviour.cs
@@ -80,15 +80,19 @@ public class ArcadiaBehaviour : MonoBehaviour, ISerializationCallbackReceiver
 	public void OnAfterDeserialize()
 	{
 #if UNITY_EDITOR
-		Awake();
+		Init();
 #endif
 	}
 
 	private static IFn requireFn = null;
 
 	// if serializedVar not null, set fn to var
-	public void Awake()
+	public virtual void Awake()
 	{
+		Init();
+	}
+
+	private void Init() {
 		if (requireFn == null)
 			requireFn = RT.var("clojure.core", "require");
 		if (qualifiedVarNames != null)

--- a/Components/AwakeHook.cs
+++ b/Components/AwakeHook.cs
@@ -3,8 +3,9 @@ using clojure.lang;
 
 public class AwakeHook : ArcadiaBehaviour   
 {
-  public void Awake()
+  public override void Awake()
   {
+      base.Awake();
       var _go = gameObject;
       foreach (var fn in fns)
         fn.invoke(_go);

--- a/Source/arcadia/internal/components.clj
+++ b/Source/arcadia/internal/components.clj
@@ -17,6 +17,14 @@
   (->> (range \a \z)
        (map (comp str char))))
 
+(def overrides
+  "Which methods of ArcadiaBehaviour should be overriden/hidden."
+  '{Awake override})
+
+(def call-base
+  "Which overriden methods should call the base method."
+  '{Awake true})
+
 (defn component-source
   ([message args] (component-source message args nil))
   ([message args interface]
@@ -30,10 +38,14 @@
 public class " (component-name message) " : ArcadiaBehaviour" (if interface (str ", " interface))
 "   
 {
-  public void " message "(" (string/join ", " (map #(str %1 " " %2) args arg-names)) ")
+  " (string/join " " (filter some? ['public (overrides message) 'void])) " "
+      message "(" (string/join ", " (map #(str %1 " " %2) args arg-names)) ")
   {
-    if(fn != null)
-      fn.invoke(" (string/join ", " (concat ['gameObject] arg-names)) ");
+" (if (call-base message)
+    (str "      base." message "(" (string/join ", " arg-names) ");\n"))
+"      var _go = gameObject;
+      foreach (var fn in fns)
+        fn.invoke(" (string/join ", " (concat ['_go] arg-names)) ");
   }
 }"))))
 


### PR DESCRIPTION
ArcadiaBehavior is the base class for all the hooks and has some logic implemented in the Awake method.  For the Awake hook to work it needs to call the base class' Awake method.

This patch updates the code used to generate the hooks so that you can specify when to call the super class and what type of method override to use.  It also changes the generated AwakeHook class.

Fixes #187