### PR TITLE
Fix update-state function

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 * Jeaye - [jeaye](https://github.com/jeaye)
 * Maxim - [2048terrabit](https://github.com/2048terrabit)
 * Douglas P. Fields, Jr. [LispEngineer](https://github.com/LispEngineer)
+* Joshua Suskalo - [IGJoshua](https://github.com/IGJoshua)

--- a/Source/arcadia/core.clj
+++ b/Source/arcadia/core.clj
@@ -585,19 +585,19 @@
   `clojure.core/update`."
   ([go k f x]
    (with-cmpt go [arcs ArcadiaState]
-     (.Add arcs (f (.ValueAtKey arcs k) x))
+     (.Add arcs k (f (.ValueAtKey arcs k) x))
      go))
   ([go k f x y]
    (with-cmpt go [arcs ArcadiaState]
-     (.Add arcs (f (.ValueAtKey arcs k) x y))
+     (.Add arcs k (f (.ValueAtKey arcs k) x y))
      go))
   ([go k f x y z]
    (with-cmpt go [arcs ArcadiaState]
-     (.Add arcs (f (.ValueAtKey arcs k) x y z))
+     (.Add arcs k (f (.ValueAtKey arcs k) x y z))
      go))
   ([go k f x y z & args]
    (with-cmpt go [arcs ArcadiaState]
-     (.Add arcs (apply f (.ValueAtKey arcs k) x y z args))
+     (.Add arcs k (apply f (.ValueAtKey arcs k) x y z args))
      go)))
 
 ;; ============================================================

--- a/Source/arcadia/core.clj
+++ b/Source/arcadia/core.clj
@@ -583,6 +583,10 @@
   "Updates the state of object `go` with function `f` and additional
   arguments `args` at key `k`. Args are applied in the same order as
   `clojure.core/update`."
+  ([go k f]
+   (with-cmpt go [arcs ArcadiaState]
+     (.Add arcs k (f (.ValueAtKey arcs k)))
+     go))
   ([go k f x]
    (with-cmpt go [arcs ArcadiaState]
      (.Add arcs k (f (.ValueAtKey arcs k) x))


### PR DESCRIPTION
In the current branch the update-state function doesn't work at all. This fixes that issue and adds a 3-arity version of the update-state function to allow the passed iFn to only take the original state instead of having to take additional parameters.