### PR TITLE
Fix if-cmpt else clause

### DIFF
--- a/Source/arcadia/core.clj
+++ b/Source/arcadia/core.clj
@@ -370,12 +370,13 @@
   "Execute body of code if `gob` has a component of type `cmpt-type`"
   [gob [cmpt-name cmpt-type] then & else]
   (let [gobsym (gentagged "gob__" 'UnityEngine.GameObject)]
-    `(if (obj-nil ~gob)
-       (with-gobj [~gobsym ~gob]
-         (if-let [~(meta-tag cmpt-name cmpt-type) (cmpt ~gobsym ~cmpt-type)]
-           ~then
-           ~@else))
-       ~@else)))
+    `(let [obj# ~gob]
+       (if (obj-nil obj#)
+         (with-gobj [~gobsym obj#]
+           (if-let [~(meta-tag cmpt-name cmpt-type) (cmpt ~gobsym ~cmpt-type)]
+             ~then
+             ~@else))
+         ~@else))))
 
 ;; ============================================================
 ;; traversal

--- a/Source/arcadia/core.clj
+++ b/Source/arcadia/core.clj
@@ -368,14 +368,14 @@
 
 (defmacro if-cmpt
   "Execute body of code if `gob` has a component of type `cmpt-type`"
-  [gob [cmpt-name cmpt-type] then & [else]]
+  [gob [cmpt-name cmpt-type] then & else]
   (let [gobsym (gentagged "gob__" 'UnityEngine.GameObject)]
     `(if (obj-nil ~gob)
        (with-gobj [~gobsym ~gob]
          (if-let [~(meta-tag cmpt-name cmpt-type) (cmpt ~gobsym ~cmpt-type)]
            ~then
-           ~else))
-       ~else)))
+           ~@else))
+       ~@else)))
 
 ;; ============================================================
 ;; traversal

--- a/Source/arcadia/core.clj
+++ b/Source/arcadia/core.clj
@@ -368,15 +368,14 @@
 
 (defmacro if-cmpt
   "Execute body of code if `gob` has a component of type `cmpt-type`"
-  ([gob [cmpt-name cmpt-type] then]
-   `(with-cmpt ~gob [~cmpt-name ~cmpt-type]
-      (when ~cmpt-name
-        ~then)))
-  ([gob [cmpt-name cmpt-type] then else]
-   `(with-cmpt ~gob [~cmpt-name ~cmpt-type]
-      (if ~cmpt-name
-        ~then
-        ~else))))
+  [gob [cmpt-name cmpt-type] then & [else]]
+  (let [gobsym (gentagged "gob__" 'UnityEngine.GameObject)]
+    `(if (obj-nil ~gob)
+       (with-gobj [~gobsym ~gob]
+         (if-let [~(meta-tag cmpt-name cmpt-type) (cmpt ~gobsym ~cmpt-type)]
+           ~then
+           ~else))
+       ~else)))
 
 ;; ============================================================
 ;; traversal


### PR DESCRIPTION
This commit makes if-cmpt to use cmpt instead of ensure-cmpt. 
If the game object is nil, it will do the else clause.