### PR TITLE
Fixes a udp receive thread crash

### DIFF
--- a/Source/arcadia/repl.clj
+++ b/Source/arcadia/repl.clj
@@ -250,7 +250,7 @@
                                         (catch SocketException ex
                                           (if (not= (.ErrorCode ex) SocketError/TimedOut)
                                             (throw (Exception. "Unexpected Socket error" ex))))))
-                                     ;; TODO why does this line not execute?
+                                     (.Close socket)
                                      (if ((config/config) :verbose)
                                        (Debug/Log "REPL Stopped")))))
       socket)))
@@ -260,5 +260,4 @@
     (Debug/Log "Stopping REPL..."))
   (locking server-running
     (when @server-running
-      (reset! server-running false)
-      (.Close socket))))
+      (reset! server-running false))))


### PR DESCRIPTION
Fixed a bug where the GUI thread was closing a socket while another one was in the middle of using it in a blocking fashion. The blocking thread was probably crashing (it was not even throwing a ObjectDisposedException) which is why the following lines were not evaluated.

There are other problems in the start-server / stop-server, but I prefer them to be fixed altogether in another PR.