### PR TITLE
Support reader conditionals via NRepl

### DIFF
--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -176,12 +176,13 @@ namespace Arcadia
 				var sessionBindings = _sessions[session];
 				var outWriter = new Writer("out", _request, _client);
 				var errWriter = new Writer("err", _request, _client);
+				var optsMap = RT.map(Keyword.intern("read-cond"), Keyword.intern("allow"));
 
 				Var.pushThreadBindings(sessionBindings
 						.assoc(RT.OutVar, outWriter)
 						.assoc(RT.ErrVar, errWriter));
 				try {
-					var form = readStringVar.invoke(code);
+					var form = readStringVar.invoke(optsMap, code);
 					var result = evalVar.invoke(form);
 					var value = (string)prStrVar.invoke(result);
 


### PR DESCRIPTION
This is an attempt at supporting reader conditionals via Arcadia's NRepl.

NRepl.cs was modified so that read-string is called with an options map:

```clojure
{:read-cond :allow}
```

Before this change, sending code with reader conditionals in it via the NRepl was leading to an exception:

```
System.InvalidOperationException: Conditional read not allowed
  clojure.lang.LispReader.checkConditionalAllowed (object)
* clojure.lang.LispReader+ConditionalReader.Read
* clojure.lang.LispReader+ReaderBase
* clojure.lang.LispReader+DispatchReader.Read
* clojure.lang.LispReader+ReaderBase
  clojure.lang.LispReader.read (clojure.lang.PushbackTextReader, System.Boolean, object, System.Nullable`1[System.Char], object, System.Boolean, object, object, clojure.lang.LispReader+Resolver)
  clojure.lang.LispReader.ReadDelimitedList (System.Char, clojure.lang.PushbackTextReader, System.Boolean, object, object)
* clojure.lang.LispReader+ListReader.Read
* clojure.lang.LispReader+ReaderBase
  clojure.lang.LispReader.read (clojure.lang.PushbackTextReader, System.Boolean, object, System.Nullable`1[System.Char], object, System.Boolean, object, object, clojure.lang.LispReader+Resolver)
  clojure.lang.LispReader.ReadDelimitedList (System.Char, clojure.lang.PushbackTextReader, System.Boolean, object, object)
* clojure.lang.LispReader+ListReader.Read
* clojure.lang.LispReader+ReaderBase
  clojure.lang.LispReader.read (clojure.lang.PushbackTextReader, System.Boolean, object, System.Nullable`1[System.Char], object, System.Boolean, object, object, clojure.lang.LispReader+Resolver)
  clojure.lang.LispReader.read (clojure.lang.PushbackTextReader, System.Boolean, object, System.Boolean, object)
  clojure.lang.LispReader.read (clojure.lang.PushbackTextReader, object)
  clojure.lang.RT.readString (System.String, object)
  clojure.lang.RT.readString (System.String)
* clojure/core/read-string
* clojure.lang.Var
* Arcadia.NRepl+EvalFn your-fine-project-name-here/Assets/Arcadia/Editor/NRepl.cs (184:0)
```