### PR TITLE
Multiple NRepls.cs improvements

### DIFF
--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -352,7 +352,7 @@ namespace Arcadia
 		{
 			var opValue = message["op"];
 			var opString = opValue as BString;
-			var autoCompletionSupportEnabled = (bool)((IPersistentMap)configVar.invoke()).valAt(Keyword.intern("nrepl-auto-completion"));
+			var autoCompletionSupportEnabled = RT.booleanCast(((IPersistentMap)configVar.invoke()).valAt(Keyword.intern("nrepl-auto-completion")));
 			if (opString != null) {
 				var session = GetSession(message);
 				switch (opString.ToString()) {

--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -198,7 +198,7 @@ namespace Arcadia
 				var outWriter = new Writer("out", _request, _client);
 				var errWriter = new Writer("err", _request, _client);
 
-				Debug.Log("Evaling code in " + _request["file"]);
+				// Debug.Log("Evaling code in " + _request["file"]);
 
 				
 				// Split the path, and try to infer the ns from the filename. If the ns exists, then change the current ns before evaluating
@@ -385,17 +385,25 @@ namespace Arcadia
 					var loadFn = new EvalFn(message, client);
 					addCallbackVar.invoke(loadFn);
 					break;
-				case "info":
 				case "eldoc":
+				case "info":
 
                     String symbolStr = message["symbol"].ToString();
 
                     // Editors like Calva that support doc-on-hover sometimes will ask about empty strings or spaces
 					if (symbolStr == "" || symbolStr == null || symbolStr == " ") break;
 
-					var symbolMetadata = (IPersistentMap)metaVar.invoke(nsResolveVar.invoke(
-						findNsVar.invoke(symbolVar.invoke(message["ns"].ToString())),
-						symbolVar.invoke(symbolStr)));
+					IPersistentMap symbolMetadata = null;
+					try
+					{
+                        symbolMetadata = (IPersistentMap)metaVar.invoke(nsResolveVar.invoke(
+                            findNsVar.invoke(symbolVar.invoke(message["ns"].ToString())),
+                            symbolVar.invoke(symbolStr)));
+					} catch (TypeNotFoundException) { 
+							// We'll just ignore this call if the type cannot be found. This happens sometimes.
+							// TODO: One particular case when this happens is when querying info for a namespace. 
+							//       That case should be handled separately (e.g., via `find-ns`?)
+						}
 
 
 					if (symbolMetadata != null) {

--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -346,9 +346,16 @@ namespace Arcadia
 					addCallbackVar.invoke(loadFn);
 					break;
 				case "info":
+
+                    String symbolStr = message["symbol"].ToString();
+
+                    // Editor like Calva that support doc-on-hover sometimes will ask about empty strings or spaces
+					if (symbolStr == "" || symbolStr == null || symbolStr == " ") break;
+
 					var symbolMetadata = (IPersistentMap)metaVar.invoke(nsResolveVar.invoke(
 						findNsVar.invoke(symbolVar.invoke(message["ns"].ToString())),
-						symbolVar.invoke(message["symbol"].ToString())));
+						symbolVar.invoke(symbolStr)));
+
 
 					if (symbolMetadata != null) {
 						var resultMessage = new BDictionary {
@@ -356,12 +363,20 @@ namespace Arcadia
 							{"session", session.ToString()},
 							{"status", new BList {"done"}}
 						};
+
 						foreach (var entry in symbolMetadata) {
 							if (entry.val() != null) {
-								resultMessage[entry.key().ToString().Substring(1)] =
-									new BString(entry.val().ToString());
+								String keyStr = entry.key().ToString().Substring(1);
+								String keyVal = entry.val().ToString();
+								if (keyStr == "arglists") {
+									keyStr = "arglists-str";
 								}
-							}
+								if (keyStr == "forms") {
+									keyStr = "forms-str";
+								}
+								resultMessage[keyStr] = new BString(keyVal);
+						    }
+					    }
 							SendMessage(resultMessage, client);
 					} else {
 							SendMessage(

--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -201,10 +201,10 @@ namespace Arcadia
 				
 				// Split the path, and try to infer the ns from the filename. If the ns exists, then change the current ns before evaluating
 				List<String> nsList = new List<String>();
-				var path = _request["file"].ToString();
 				Namespace fileNs = null;
 				try
 				{
+					var path = _request["file"].ToString();
 					string current = null;
 					while (path != null && current != "Assets")
 					{

--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -426,10 +426,10 @@ namespace Arcadia
 					}
 					break;
 				case "complete":
-					foreach (var k in message.Keys)
-					{
-                        Debug.Log(k.ToString() + ": " + message[k].ToString());
-					}
+					//foreach (var k in message.Keys)
+					//{
+                     //   Debug.Log(k.ToString() + ": " + message[k].ToString());
+					//}
 
 					Namespace ns = Namespace.find(Symbol.create(message["ns"].ToString()));
                     var sessionBindings = _sessions[session];

--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -381,7 +381,7 @@ namespace Arcadia
                         {"info", 1},
                         {"eldoc", 1},
                     };
-					Debug.Log("Autocomplete support is enabled?: " + autoCompletionSupportEnabled);
+					// Debug.Log("Autocomplete support is enabled?: " + autoCompletionSupportEnabled);
 					if (autoCompletionSupportEnabled) {
 						supportedOps.Add("complete", 1);
 					}
@@ -482,7 +482,7 @@ namespace Arcadia
 
 					// When autoCompletionSupportEnabled is false, we don't advertise auto-completion support. 
 					// some editors seem to ignore this and request anyway, so we return an unknown op message.
-					if (!autoCompletionSupportEnabled)  {
+					if (!autoCompletionSupportEnabled) {
                         SendMessage(
                             new BDictionary
                             {

--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -480,17 +480,19 @@ namespace Arcadia
                         }, client);
 					break;
 				case "classpath":
-                    // Debug.Log("Classpath op has been called");
-					string assetsPath = Path.Combine(Path.GetFullPath("."), "Assets");
-					string arcadiaSrcPath = Path.Combine(assetsPath, "Arcadia", "Source");
-                    // Debug.Log("assetsPath: " + assetsPath);
-                    // Debug.Log("arcadiaSrcPath: " + arcadiaSrcPath);
+                    BList classpath = new BList();
+					foreach (String p in Environment.GetEnvironmentVariable("CLOJURE_LOAD_PATH").Split(System.IO.Path.PathSeparator)) {
+						if (p != "") {
+                            classpath.Add(Path.GetFullPath(p));
+                        }
+                    }
+
 					SendMessage(new BDictionary
                         {
                             {"id", message["id"]},
                             {"session", session.ToString()},
                             {"status", new BList {"done"}},
-							{"classpath", new BList { assetsPath, arcadiaSrcPath }},
+							{"classpath", classpath},
                         }, client);
 					break;
 				default:

--- a/Source/arcadia/internal/autocompletion.clj
+++ b/Source/arcadia/internal/autocompletion.clj
@@ -1,0 +1,112 @@
+(ns arcadia.internal.autocompletion
+  (:require [clojure.main]))
+
+;; This namespace has been adapted from a fork of the `clojure-complete` library by @sogaiu:
+;; https://github.com/sogaiu/clojure-complete/blob/clr-support/src/complete/core.cljc
+;; The original code was in turn adapted from swank-clojure (http://github.com/jochu/swank-clojure)
+;; List of changes:
+;; - Added support for keyword autocompletion
+;; - Removed conditional reader tags
+
+(defn namespaces
+  "Returns a list of potential namespace completions for a given namespace"
+  [ns]
+  (map name (concat (map ns-name (all-ns)) (keys (ns-aliases ns)))))
+
+(defn ns-public-vars
+  "Returns a list of potential public var name completions for a given
+  namespace"
+  [ns]
+  (map name (keys (ns-publics ns))))
+
+(defn ns-vars
+  "Returns a list of all potential var name completions for a given namespace"
+  [ns]
+  (for [[sym val] (ns-map ns) :when (var? val)]
+    (name sym)))
+
+(defn ns-classes
+  "Returns a list of potential class name completions for a given namespace"
+  [ns]
+  (map name (keys (ns-imports ns))))
+
+(def special-forms
+  (map name '[def if do let quote var fn loop recur throw try monitor-enter
+              monitor-exit dot new set!]))
+
+(defn- static? [member]
+  (.IsStatic member))
+
+(defn static-members
+  "Returns a list of potential static members for a given class"
+  [^System.RuntimeType class]
+  (for [member (concat (.GetMethods class)
+                       (.GetFields class)
+                       '()) :when (static? member)]
+    (.Name member)))
+
+(defn resolve-class [sym]
+  (try (let [val (resolve sym)]
+         (when (class? val) val))
+       (catch Exception e
+         (when (not= clojure.lang.TypeNotFoundException
+                     (class (clojure.main/repl-exception e)))
+           (throw e)))))
+
+(defmulti potential-completions
+  (fn [^String prefix ns]
+    (cond (.Contains prefix "/") :scoped
+          (.Contains prefix ".") :class
+          (.StartsWith prefix ":") :keyword
+          :else :var)))
+
+(defmethod potential-completions :scoped
+  [^String prefix ns]
+  (when-let [prefix-scope
+             (first (let [[x & _ :as pieces]
+                          (.Split prefix (.ToCharArray "/"))]
+                      (if (= x "")
+                        '()
+                        pieces)))]
+    (let [scope (symbol prefix-scope)]
+      (map #(str scope "/" %)
+           (if-let [class (resolve-class scope)]
+             (static-members class)
+             (when-let [ns (or (find-ns scope)
+                               (scope (ns-aliases ns)))]
+               (ns-public-vars ns)))))))
+
+(defmethod potential-completions :class
+  [^String prefix ns]
+  (concat (namespaces ns)))
+
+(defmethod potential-completions :var
+  [_ ns]
+  (concat special-forms
+          (namespaces ns)
+          (ns-vars ns)
+          (ns-classes ns)))
+
+(def sym-key-map
+  (-> clojure.lang.Keyword
+      (.GetField "_symKeyMap" (enum-or BindingFlags/NonPublic BindingFlags/Static))
+      (.GetValue nil)))
+
+(defmethod potential-completions :keyword
+  [_ _]
+  (let [keyword-candidate-list
+        (->> sym-key-map
+             (.Values)
+             (map #(str (.Target %))))]
+    keyword-candidate-list))
+
+(defn completions
+  "Return a sequence of matching completions given a prefix string and an
+  optional current namespace."
+  ([prefix] (completions prefix *ns*))
+  ([^String prefix ns]
+   (-> (for [^String completion (potential-completions prefix ns)
+             :when (.StartsWith completion prefix)]
+         completion)
+       distinct
+       sort)))

--- a/Source/arcadia/internal/autocompletion.clj
+++ b/Source/arcadia/internal/autocompletion.clj
@@ -55,9 +55,9 @@
 
 (defmulti potential-completions
   (fn [^String prefix ns]
-    (cond (.Contains prefix "/") :scoped
+    (cond (.StartsWith prefix ":") :keyword
+          (.Contains prefix "/") :scoped
           (.Contains prefix ".") :class
-          (.StartsWith prefix ":") :keyword
           :else :var)))
 
 (defmethod potential-completions :scoped

--- a/Source/arcadia/internal/nrepl_support.clj
+++ b/Source/arcadia/internal/nrepl_support.clj
@@ -1,0 +1,67 @@
+(ns arcadia.internal.nrepl-support
+  (:import [BList]
+           [BDictionary]))
+
+(defn complete-symbol [text]
+  (let [[ns prefix-str] (as-> text <>
+                          (symbol <>)
+                          [(some-> <> namespace symbol) (name <>)])
+        ns-to-check (if ns
+                      (or ((ns-aliases *ns*) ns) (find-ns ns))
+                      *ns*)
+        fn-candidate-list (when ns-to-check
+                            (if ns
+                              (map str (keys (ns-publics ns-to-check)))
+                              (map str (keys (ns-map ns-to-check)))))]
+    (into '() (comp (filter #(.StartsWith % prefix-str))
+                    (map #(if ns (str ns "/" %) %))
+                    (map #(-> {:candidate %
+                               :type "function"})))
+          (concat
+           fn-candidate-list))))
+
+(defn complete-namespace [text]
+  (let [[ns prefix-str] (as-> text <>
+                          (symbol <>)
+                          [(some-> <> namespace symbol) (name <>)])
+        ns-candidate-list (when-not ns
+                            (map (comp str ns-name) (all-ns)))]
+    (into '() (comp (filter #(.StartsWith % prefix-str))
+                    (map str)
+                    (map #(-> {:candidate %
+                               :type "namespace"})))
+          ns-candidate-list)))
+
+(defn complete-keyword [text]
+  (let [keyword-candidate-list
+        ;; NOTE: :_ is used here to get an instance to some keyword.
+        (as-> :_ <>
+          (.GetType <>)
+          (.GetField <> "_symKeyMap" (enum-or BindingFlags/NonPublic
+                                              BindingFlags/Static))
+          (.GetValue <> :_)
+          (.Values <>)
+          (map #(str (.Target %)) <>))]
+    (into '() (comp (filter #(.StartsWith % text))
+                    (map #(-> {:candidate %
+                               :type "keyword"})))
+          keyword-candidate-list)))
+
+(defn bencode-result
+  "Converts a seq of completion maps into a BList of BDictionary"
+  [completions]
+  (let [blist (BList.)]
+    (doseq [{:keys [candidate, type]} completions]
+      (.Add blist (doto (BDictionary.)
+                    (.Add "candidate" candidate)
+                    (.Add "type" type))))
+    blist))
+
+(defn complete [^String prefix]
+  (bencode-result
+   (cond
+     (.StartsWith prefix ":") (complete-keyword prefix)
+     (.Contains prefix "/") (complete-symbol prefix)
+     :else
+     (concat (complete-symbol prefix)
+             (complete-namespace prefix)))))

--- a/Source/arcadia/internal/nrepl_support.clj
+++ b/Source/arcadia/internal/nrepl_support.clj
@@ -1,68 +1,18 @@
 (ns arcadia.internal.nrepl-support
+  (:require [arcadia.internal.autocompletion :as ac])
   (:import [BList]
            [BDictionary]))
 
-(defn complete-symbol [text]
-  (let [[ns prefix-str] (as-> text <>
-                          (symbol <>)
-                          [(some-> <> namespace symbol) (name <>)])
-        ns-to-check (if ns
-                      (or ((ns-aliases *ns*) ns) (find-ns ns))
-                      *ns*)
-        fn-candidate-list (when ns-to-check
-                            (if ns
-                              (map str (keys (ns-publics ns-to-check)))
-                              (map str (keys (ns-map ns-to-check)))))]
-    (into '() (comp (filter #(.StartsWith % prefix-str))
-                    (map #(if ns (str ns "/" %) %))
-                    (map #(-> {:candidate %
-                               :type "function"})))
-          (concat
-           fn-candidate-list))))
-
-(defn complete-namespace [text]
-  (let [[ns prefix-str] (as-> text <>
-                          (symbol <>)
-                          [(some-> <> namespace symbol) (name <>)])
-        ns-candidate-list (when-not ns
-                            (map (comp str ns-name) (all-ns)))]
-    (into '() (comp (filter #(.StartsWith % prefix-str))
-                    (map str)
-                    (map #(-> {:candidate %
-                               :type "namespace"})))
-          ns-candidate-list)))
-
-(def sym-key-map
-  (-> clojure.lang.Keyword
-      (.GetField "_symKeyMap" (enum-or BindingFlags/NonPublic BindingFlags/Static))
-      (.GetValue nil)))
-
-(defn complete-keyword [text]
-  (let [keyword-candidate-list
-        ;; NOTE: :_ is used here to get an instance to some keyword.
-        (->> sym-key-map
-             (.Values)
-             (map #(str (.Target %))))]
-    (into '() (comp (filter #(.StartsWith % text))
-                    (map #(-> {:candidate %
-                               :type "keyword"})))
-          keyword-candidate-list)))
-
-(defn bencode-result
+(defn bencode-completion-result
   "Converts a seq of completion maps into a BList of BDictionary"
   [completions]
   (let [blist (BList.)]
-    (doseq [{:keys [candidate, type]} completions]
+    (doseq [candidate completions]
       (.Add blist (doto (BDictionary.)
-                    (.Add "candidate" candidate)
-                    (.Add "type" type))))
+                    (.Add "candidate" candidate))))
     blist))
 
 (defn complete [^String prefix]
-  (bencode-result
-   (cond
-     (.StartsWith prefix ":") (complete-keyword prefix)
-     (.Contains prefix "/") (complete-symbol prefix)
-     :else
-     (concat (complete-symbol prefix)
-             (complete-namespace prefix)))))
+  (bencode-completion-result
+   (ac/completions prefix)))
+

--- a/Source/arcadia/internal/nrepl_support.clj
+++ b/Source/arcadia/internal/nrepl_support.clj
@@ -32,16 +32,17 @@
                                :type "namespace"})))
           ns-candidate-list)))
 
+(def sym-key-map
+  (-> clojure.lang.Keyword
+      (.GetField "_symKeyMap" (enum-or BindingFlags/NonPublic BindingFlags/Static))
+      (.GetValue nil)))
+
 (defn complete-keyword [text]
   (let [keyword-candidate-list
         ;; NOTE: :_ is used here to get an instance to some keyword.
-        (as-> :_ <>
-          (.GetType <>)
-          (.GetField <> "_symKeyMap" (enum-or BindingFlags/NonPublic
-                                              BindingFlags/Static))
-          (.GetValue <> :_)
-          (.Values <>)
-          (map #(str (.Target %)) <>))]
+        (->> sym-key-map
+             (.Values)
+             (map #(str (.Target %))))]
     (into '() (comp (filter #(.StartsWith % text))
                     (map #(-> {:candidate %
                                :type "keyword"})))

--- a/configuration.edn
+++ b/configuration.edn
@@ -60,5 +60,21 @@
  ;; see https://github.com/arcadia-unity/Arcadia/wiki/Stacktraces-and-Error-Reporting
  ;; for options on formatting thrown Exceptions
  ;; :error-options {:format true}
+
+
+ ;; This boolean variable controls whether auto-completion support on an nrepl
+ ;; connection is enabled. When enabled, the nREPL server will answer requests
+ ;; to the "complete" message with the following information:
+ ;;
+ ;; - Autocomplete fns in current namespace: The server tries to complete all
+ ;;   the symbols available to the current context. That is, the public vars of
+ ;;   the current namespace, as well as any `use` or `:refer :all` imported symbols.
+ ;; - Autocomplete fns from other namespaces: You can also autocomplete things
+ ;;   from other namespaces, both via alias, e.g. `str/split`, and fully
+ ;;   qualified name, e.g. `clojure.string/split`.
+ ;; - Autocomplete namespaces: The name of namespaces is also autocompleted.
+ ;; - Autocomplete keywords: Any keywords used (i.e., interned) in the project
+ ;;   are also autocompleted.
+ :nrepl-auto-completion true
  }
 


### PR DESCRIPTION
Support for sending symbol metadata information via NRepl was incomplete because the `:forms` and `:arglists` typically present in symbol's metadata are expected to have different names: `:forms-str` and `:arglists-str`. This is related to the fact that these two keys usually contain edn that should not be parsed directly. 

With this PR, the nrepl client in NRepl.cs now does the right thing and sends the `-str` version of the keys. This means that the argument list for user-defined fns and documentation for special forms (like `let`) should be now shown by most editor plugins. I've tested this behaviour to be correct both with Emacs (CIDER) and VSCode (Calva).

This PR also gets rid of a minor annoyance with Calva (and probably other editors that show documentation on mouse hover) where sometimes it would ask our nrepl server for an empty string, making it throw an exception that was logged to the Unity console. Now those empty string queries are properly ignored, making the Arcadia experience in Calva better.