### PR TITLE
Added support for :ns key in nrepl message to cause eval to be within the namespace

### DIFF
--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -209,22 +209,38 @@ namespace Arcadia
 				// Split the path, and try to infer the ns from the filename. If the ns exists, then change the current ns before evaluating
 				List<String> nsList = new List<String>();
 				Namespace fileNs = null;
+				Namespace priorNs = null;
 				try
 				{
-					var path = _request["file"].ToString();
-					string current = null;
-					while (path != null && current != "Assets")
-					{
-						current = Path.GetFileNameWithoutExtension(path);
-						nsList.Add(current);
-						path = Directory.GetParent(path).FullName;
+					// Debug.Log(string.Join(", ", _request.Value));
+					if (_request.ContainsKey("ns")) {
+						// Debug.Log("Trying to find: " + _request["ns"].ToString());
+						fileNs = Namespace.find(Symbol.create(_request["ns"].ToString()));
+						// Debug.Log("Found: " + _request["ns"].ToString());
+					} else {
+						fileNs = Namespace.find(Symbol.create(RT.CurrentNSVar.deref().ToString()));
+						Debug.Log("CurrentNSVar: " + RT.CurrentNSVar.deref().ToString());
 					}
-					nsList.Reverse();
-					nsList.RemoveAt(0);
-					// Debug.Log("Trying to find: " + string.Join(".", nsList.ToArray()));
-					fileNs = Namespace.find(Symbol.create(string.Join(".", nsList.ToArray())));
-					// Debug.Log("Found: " + string.Join(".", nsList.ToArray()));
-				} 
+
+					// I don't know how the file functionality is exactly supposed to work,
+					//   so I'll leave this here to override if the key is set.
+					//   I expect in PR review we'll fix this =)...
+					if (_request.ContainsKey("file")) {
+						var path = _request["file"].ToString();
+						string current = null;
+						while (path != null && current != "Assets")
+						{
+							current = Path.GetFileNameWithoutExtension(path);
+							nsList.Add(current);
+							path = Directory.GetParent(path).FullName;
+						}
+						nsList.Reverse();
+						nsList.RemoveAt(0);
+						// Debug.Log("Trying to find: " + string.Join(".", nsList.ToArray()));
+						fileNs = Namespace.find(Symbol.create(string.Join(".", nsList.ToArray())));
+						// Debug.Log("Found: " + string.Join(".", nsList.ToArray()));
+					}
+				}
 				catch (Exception e)
 				{ 
 					/* Whatever sent in :file was not a path. Ignore it */

--- a/Helpers/LinearHelper.cs
+++ b/Helpers/LinearHelper.cs
@@ -13,6 +13,13 @@ namespace Arcadia {
             return PersistentVector.create(ang, axis);
         }
 
+        public static IPersistentVector smoothDamp(Vector3 current, Vector3 target, Vector3 currentVelocity, float smoothTime)
+        {
+            Vector3 newCurrentVelocity = currentVelocity;
+            Vector3 result = Vector3.SmoothDamp(current, target, ref newCurrentVelocity, smoothTime);
+            return PersistentVector.create(result, newCurrentVelocity);
+        }
+
 		public static Matrix4x4 matrix (
 			float a, float b, float c, float d,
 			float e, float f, float g, float h,

--- a/Source/arcadia/linear.clj
+++ b/Source/arcadia/linear.clj
@@ -341,6 +341,17 @@ Calls to this function will be inlined if possible."})
 ;; dist
 
 ;; ------------------------------------------------------------
+;; smooth damp
+
+(definline smooth-damp
+  "Given a `Vector3` `current`, a `Vector3` `target` a `Vector3` `current-velocity` and a `float` `smooth-time`, returns a collection containing the result (`Vector3`) of smoothly changing from the current to the target over the time smooth-time and current-velocity (`Vector3`), as set by the `Vector3/SmoothDamp`.
+
+  Calls to this function will be inlined if possible."
+  [^UnityEngine.Vector3 current ^UnityEngine.Vector3 target ^UnityEngine.Vector3 current-velocity smooth-time]
+  `(Arcadia.LinearHelper/smoothDamp ~current ~target ~current-velocity ~smooth-time))
+
+
+;; ------------------------------------------------------------
 ;; Quaternions
 ;; and then there's this
 ;; inline etc this stuff when time allows


### PR DESCRIPTION
This is to support nrepl's eval which states that:
```
:ns The namespace in which to perform the evaluation.
The supplied namespace must exist already (e.g. be loaded).
If no namespace is specified the evaluation falls back to *ns* for the session in question.
```
Documented here:
https://github.com/nrepl/nrepl/blob/master/doc/modules/ROOT/pages/ops.adoc#eval

Some additional notes:
- I'm not 100% certain if the use of eval :ns is supposed to actually change the current `*ns*` value, I don't believe it's supposed to. If it is supposed to change the current `*ns*` value, then line 212, can be deleted.
  Otherwise the code below will need to be inserted somewhere to create this effect:
```
// We need to return the ns to the prior value
if (priorNs != null)
{
	// Debug.Log("Current ns: " + fileNs.ToString());
	evalBindings = evalBindings.assoc(RT.CurrentNSVar, priorNs);
}
```

- Additionally I've written some statements that I believe should be true =)... Sorry if it's not 100% bit tired at this point ;)...

  Things that should work!
1) Does calling an unqualified function within a namespace invoke it within that namespace?

Load in this file:
```clojure
(ns game.core
  (:require [arcadia.core :as arc])
  (:import [UnityEngine GameObject]))

(defn log-name [obj role-key]
  (arc/log (.name obj)))

(def main-object (atom nil))

(defn create-main []
  (if-let [main-obj (arc/object-named "Main")]
    (reset! main-object main-obj)
    (swap! main-object (fn [n] (new UnityEngine.GameObject "Main")))))

(defn hook-main []
  (arc/hook+
    @main-object
    :start
    :log-name
    ;; in log-name `obj` will be the `the-object`, `role-key` will be `:log-name`
    #'log-name))
```

Then eval the below within the comment block in that same namespace!

Having evaled this:
```
(do
  (in-ns 'user)
  (defn create-main []
    (println "THIS IS THE WRONG ONE!"))

  (defn hook-main []
    (println "THIS IS THE WRONG ONE!")))
```

Then this:
```
(ns-publics 'game.core)
```

should give:
```
{main-object #'game.core/main-object,
 create-main #'game.core/create-main,
 hook-main #'game.core/hook-main,
 log-name #'game.core/log-name}
```

and evaling this:
```
(create-main)
```

should not give:
```
THIS IS THE WRONG ONE!
=> nil
```

But instead give:
```
=> #<Main (UnityEngine.GameObject)>
```

2) Calling `(in-ns 'some.namespace)` should change the namespace to some.namespace.

This must work, evaling the below:
```
(do
    (in-ns 'user)
    (defn hook-main []
      (println "THIS IS THE WRONG ONE!")))
```

should produce in the REPL:
```
=> #'user/hook-main
```

This currently doesn't work:
```
(identity *ns*)
=> #object[Namespace 0xaf89a000 "game.core"]
(in-ns 'game.fishing)
=> #object[Namespace 0x74822e00 "game.fishing"]
(identity *ns*)
=> #object[Namespace 0xaf89a000 "game.core"]
```

The `*ns*` should have changed to `game.fishing`, but stays as `game.core` as that was the namespace it was called from. Directly entering it into the REPL will change the namespace.

3) Evaling code within a different namespace shouldn't change the current namespace.
__(I'm not 100% certain this is correct behaviour)__

Finally, this is all a bit rough and ready, I just wanted to get a conversation started about what it needs to look like and make sure this implementation doesn't cause issues with other implementations =)...