### PR TITLE
prevent multiple instances of TcpListener causing Socket Exception

### DIFF
--- a/Editor/NRepl.cs
+++ b/Editor/NRepl.cs
@@ -515,13 +515,19 @@ namespace Arcadia
 			running = false;
 		}
 
+		private static TcpListener listener;
+
 		public static void StartServer ()
 		{
 			Debug.Log("nrepl: starting");
 			
 			running = true;
 			new Thread(() => {
-				var listener = new TcpListener(IPAddress.Loopback, Port);
+				if (listener == null)
+				{
+					listener = new TcpListener(IPAddress.Loopback, Port);
+				}
+				
 				try
 				{
 					// TODO make IPAddress.Loopback configurable to allow remote connections


### PR DESCRIPTION
On Unity version 2020.3.16f1, enter->leave->enter play mode will produce a Socket Exception in the console. It seems there's a zombie instance of TcpListener in a thread still listening on 3722 while Arcadia tries to start up nrepl again. Restarting Unity seems to be the only workaround when this happens.

Maintaining a single instance of `listener` as in this change is resilient to many play/stop/play cycles. I don't know enough about Arcadia's architecture or threading in .NET to determine if this would cause other problems 😄 but so far it's working for me.